### PR TITLE
Google Dark

### DIFF
--- a/lib/button_list.dart
+++ b/lib/button_list.dart
@@ -2,6 +2,7 @@ enum Buttons {
   /// This is a list of all the library built buttons.
   Email,
   Google,
+  GoogleDark,
   Facebook,
   GitHub,
   LinkedIn,

--- a/lib/button_view.dart
+++ b/lib/button_view.dart
@@ -47,6 +47,16 @@ class SignInButton extends StatelessWidget {
           backgroundColor: Color(0xFFDD4B39),
           onPressed: onPressed,
         );
+      case Buttons.GoogleDark:
+        return SignInButtonBuilder(
+          key: ValueKey("Google"),
+          mini: mini,
+          title: 'Google',
+          icon: FontAwesomeIcons.google,
+          backgroundColor: Color(0xFF4285F4),
+          textColor: Color(0xFFFFFFFF),
+          onPressed: onPressed,
+        );
       case Buttons.Facebook:
         return SignInButtonBuilder(
           key: ValueKey("Facebook"),


### PR DESCRIPTION
Add Google dark button
Color from https://developers.google.com/identity/branding-guidelines
![Google Dark Button](https://user-images.githubusercontent.com/1871841/50630405-4e404000-0f73-11e9-91d8-2ebfcd6d1214.jpg)
