### PR TITLE
Make Button Text Fully Customizable

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,11 +28,10 @@ class SignInPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             SignInButtonBuilder(
-              title: 'Email',
+              text: 'Get going with Email',
               icon: Icons.email,
               onPressed: () {},
               backgroundColor: Colors.blueGrey[700],
-              signInText: "Get going with",
               width: 200.0,
             ),
             Divider(),
@@ -50,10 +49,12 @@ class SignInPage extends StatelessWidget {
             ),
             SignInButton(
               Buttons.Pinterest,
+              text: "Sign up with Pinterest",
               onPressed: () {},
             ),
             SignInButton(
               Buttons.Twitter,
+              text: "Use Twitter",
               onPressed: () {},
             ),
             Divider(),
@@ -72,6 +73,7 @@ class SignInPage extends StatelessWidget {
                 ),
                 SignInButtonBuilder(
                   icon: Icons.email,
+                  text: "Ignored for mini button",
                   mini: true,
                   onPressed: () {},
                   backgroundColor: Colors.cyan,

--- a/lib/button_builder.dart
+++ b/lib/button_builder.dart
@@ -11,12 +11,8 @@ class SignInButtonBuilder extends StatelessWidget {
   /// `mini` tag is used to switch from a full-width signin button to
   final bool mini;
 
-  /// a square button with only icon itself.
-  /// and hence the title tag is optional.
-  final String title;
-
-  /// Localize the text on the button
-  final String signInText;
+  /// the button's text
+  final String text;
 
   /// backgroundColor is required but textColor is default to `Colors.white`
   /// splashColor is defalt to `Colors.white30`
@@ -45,15 +41,14 @@ class SignInButtonBuilder extends StatelessWidget {
     @required this.icon,
     @required this.backgroundColor,
     @required this.onPressed,
-    this.title = '',
-    this.signInText = 'Sign in with',
+    @required this.text,
     this.textColor = Colors.white,
     this.splashColor = Colors.white30,
     this.padding = const EdgeInsets.all(3.0),
     this.mini = false,
     this.elevation = 2.0,
     this.width = null,
-  })  : assert(title != null),
+  })  : assert(text != null),
         assert(icon != null),
         assert(textColor != null),
         assert(backgroundColor != null),
@@ -90,15 +85,14 @@ class SignInButtonBuilder extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: <Widget>[
                     Padding(
-                      padding: EdgeInsets.symmetric(
-                          horizontal: MediaQuery.of(context).size.width / 20),
+                      padding: EdgeInsets.symmetric(horizontal: MediaQuery.of(context).size.width / 20),
                       child: Icon(
                         icon,
                         color: Colors.white,
                       ),
                     ),
                     Text(
-                      "$signInText $title",
+                      text,
                       style: TextStyle(
                         fontFamily: 'Roboto',
                         color: textColor,

--- a/lib/button_view.dart
+++ b/lib/button_view.dart
@@ -20,8 +20,11 @@ class SignInButton extends StatelessWidget {
   /// mini is a boolean field which specify whether to use a square mini button.
   final bool mini;
 
+  /// overrides the default button text
+  final String text;
+
   /// The constructor is fairly self-explanatory.
-  SignInButton(this.button, {@required this.onPressed, this.mini = false})
+  SignInButton(this.button, {@required this.onPressed, this.mini = false, this.text = null})
       : assert(button != null),
         assert(onPressed != null);
 
@@ -30,39 +33,21 @@ class SignInButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     switch (button) {
-      case Buttons.Email:
-        return SignInButtonBuilder(
-          key: ValueKey("Email"),
-          mini: mini,
-          title: 'Email',
-          icon: Icons.email,
-          onPressed: onPressed,
-          backgroundColor: Colors.grey[700],
-        );
       case Buttons.Google:
-        return SignInButtonBuilder(
-          key: ValueKey("Google"),
-          mini: mini,
-          title: 'Google',
-          icon: FontAwesomeIcons.google,
-          backgroundColor: Color(0xFFDD4B39),
-          onPressed: onPressed,
-        );
       case Buttons.GoogleDark:
         return SignInButtonBuilder(
           key: ValueKey("Google"),
           mini: mini,
-          title: 'Google',
+          text: text ?? 'Sign in with Google',
           icon: FontAwesomeIcons.google,
-          backgroundColor: Color(0xFF4285F4),
-          textColor: Color(0xFFFFFFFF),
+          backgroundColor: button == Buttons.Google ? Color(0xFFDD4B39) : Color(0xFF4285F4),
           onPressed: onPressed,
         );
       case Buttons.Facebook:
         return SignInButtonBuilder(
           key: ValueKey("Facebook"),
           mini: mini,
-          title: 'Facebook',
+          text: text ?? 'Sign in with Facebook',
           icon: FontAwesomeIcons.facebookF,
           backgroundColor: Color(0xFF3B5998),
           onPressed: onPressed,
@@ -71,7 +56,7 @@ class SignInButton extends StatelessWidget {
         return SignInButtonBuilder(
           key: ValueKey("GitHub"),
           mini: mini,
-          title: 'GitHub',
+          text: text ?? 'Sign in with GitHub',
           icon: FontAwesomeIcons.github,
           backgroundColor: Color(0xFF444444),
           onPressed: onPressed,
@@ -80,7 +65,7 @@ class SignInButton extends StatelessWidget {
         return SignInButtonBuilder(
           key: ValueKey("LinkedIn"),
           mini: mini,
-          title: 'LinkedIn',
+          text: text ?? 'Sign in with LinkedIn',
           icon: FontAwesomeIcons.linkedinIn,
           backgroundColor: Color(0xFF007BB6),
           onPressed: onPressed,
@@ -89,7 +74,7 @@ class SignInButton extends StatelessWidget {
         return SignInButtonBuilder(
           key: ValueKey("Pinterest"),
           mini: mini,
-          title: 'Pinterest',
+          text: text ?? 'Sign in with Pinterest',
           icon: FontAwesomeIcons.pinterest,
           backgroundColor: Color(0xFFCB2027),
           onPressed: onPressed,
@@ -98,7 +83,7 @@ class SignInButton extends StatelessWidget {
         return SignInButtonBuilder(
           key: ValueKey("Tumblr"),
           mini: mini,
-          title: 'Tumblr',
+          text: text ?? 'Sign in with Tumblr',
           icon: FontAwesomeIcons.tumblr,
           backgroundColor: Color(0xFF34526f),
           onPressed: onPressed,
@@ -107,7 +92,7 @@ class SignInButton extends StatelessWidget {
         return SignInButtonBuilder(
           key: ValueKey("Twitter"),
           mini: mini,
-          title: 'Twitter',
+          text: text ?? 'Sign in with Twitter',
           icon: FontAwesomeIcons.twitter,
           backgroundColor: Color(0xFF1DA1F2),
           onPressed: onPressed,
@@ -116,17 +101,18 @@ class SignInButton extends StatelessWidget {
         return SignInButtonBuilder(
           key: ValueKey("Reddit"),
           mini: mini,
-          title: 'Reddit',
+          text: text ?? 'Sign in with Reddit',
           icon: FontAwesomeIcons.reddit,
           backgroundColor: Color(0xFFFF4500),
           onPressed: onPressed,
         );
+      case Buttons.Email:
       default:
         return SignInButtonBuilder(
           key: ValueKey("Email"),
-          title: 'Email',
+          text: text ?? 'Sign in with Email',
           icon: Icons.email,
-          onPressed: () {},
+          onPressed: onPressed,
           backgroundColor: Colors.grey[700],
         );
     }


### PR DESCRIPTION
Currently it is not possible to fully customize the button text (you could only use the format `$signInText $title`). 

Also, for social login buttons in order to change the text (to something like "Sign up with Google") you had to copy the `SignInButtonBuilder` code which meant duplicating the icon/color logic. It should be possible to customize the text without worrying about the icon/color/etc.

I tried to make it easy to and clear to customize any button's text without having to use the SignInButtonBuilder for social login buttons.

Thanks for a great library!