### PR TITLE
Removed default font in button builder

### DIFF
--- a/lib/button_builder.dart
+++ b/lib/button_builder.dart
@@ -118,7 +118,6 @@ class SignInButtonBuilder extends StatelessWidget {
             Text(
               text,
               style: TextStyle(
-                fontFamily: 'Roboto',
                 color: textColor,
                 fontSize: fontSize,
                 backgroundColor: Color.fromRGBO(0, 0, 0, 0),


### PR DESCRIPTION
Let's remove the hardcoded front in TextStyle for button builder so we inherit the font family directly from the main projects theme and not the package.