### PR TITLE
Set MaterialButton widget key from parameter passed into SignInButton…

### DIFF
--- a/lib/button_builder.dart
+++ b/lib/button_builder.dart
@@ -47,6 +47,9 @@ class SignInButtonBuilder extends StatelessWidget {
   /// width is default to be 1/1.5 of the screen
   final double width;
 
+  /// Key to be passed to material button
+  final Key buttonKey;
+
   /// The constructor is self-explanatory.
   SignInButtonBuilder({
     Key key,
@@ -72,13 +75,14 @@ class SignInButtonBuilder extends StatelessWidget {
         assert(backgroundColor != null),
         assert(onPressed != null),
         assert(mini != null),
-        assert(elevation != null);
+        assert(elevation != null),
+        buttonKey = key;
 
   /// The build funtion will be help user to build the signin button widget.
   @override
   Widget build(BuildContext context) {
     return MaterialButton(
-      key: key,
+      key: buttonKey,
       minWidth: mini ? width ?? 35.0 : null,
       height: height,
       elevation: elevation,


### PR DESCRIPTION
The constructor for SignInButtonBuilder never sets the widget's key, making it difficult to use these widgets in integration tests. Here is the constructor in button_builder.dart:
````
  SignInButtonBuilder({
    Key key,
    @required this.backgroundColor,
````
This key is never used. Later in the build method, the inherited widget's key is passed to the MaterialButton. Unfortunately, this key is null as it was never set in the constructor.
````
  Widget build(BuildContext context) {
    return MaterialButton(
      key: key,
      minWidth: mini ? width ?? 35.0 : null,
````
Actually, you do not want the SignInButtonBuilder widget and the MaterialButton to have the same key since these keys should be unique. It should be fine is just set this key in the MaterialButton.