### PR TITLE
splash on google and apple buttons fixed

### DIFF
--- a/lib/button_view.dart
+++ b/lib/button_view.dart
@@ -59,6 +59,12 @@ class SignInButton extends StatelessWidget {
           elevation: elevation,
           key: ValueKey("Google"),
           text: text ?? 'Sign in with Google',
+          splashColor: button == Buttons.Google
+              ? Color.fromRGBO(224, 255, 255, 1)
+              : Colors.white30,
+          highlightColor: button == Buttons.Google
+              ? Color.fromRGBO(0, 255, 255, 0.1)
+              : Colors.white30,
           textColor: button == Buttons.Google
               ? Color.fromRGBO(0, 0, 0, 0.54)
               : Color(0xFFFFFFFF),
@@ -131,6 +137,12 @@ class SignInButton extends StatelessWidget {
         return SignInButtonBuilder(
           elevation: elevation,
           key: ValueKey("Apple"),
+          splashColor: button == Buttons.Apple
+              ? Color.fromRGBO(224, 255, 255, 1)
+              : Colors.white30,
+          highlightColor: button == Buttons.Apple
+              ? Color.fromRGBO(0, 255, 255, 0.1)
+              : Colors.white30,
           mini: mini,
           text: text ?? 'Sign in with Apple',
           textColor: button == Buttons.Apple ? Colors.black : Colors.white,


### PR DESCRIPTION
issue: #79 
added a nice splash color and highlight color for both apple and google buttons
![image](https://user-images.githubusercontent.com/60640286/125897388-5d91f674-3b8e-4e83-a069-d18c7c2305bb.png)
