### PR TITLE
Fix issue #88 : Right overflow with long text

### DIFF
--- a/lib/button_builder.dart
+++ b/lib/button_builder.dart
@@ -51,6 +51,12 @@ class SignInButtonBuilder extends StatelessWidget {
   /// width is default to be 1/1.5 of the screen
   final double? width;
 
+  /// overrides the default ellipsis text overflow
+  final TextOverflow? overflow;
+
+  /// overrides the default max lines in case of text overflow
+  final int maxLines;
+
   /// The constructor is self-explanatory.
   SignInButtonBuilder({
     Key? key,
@@ -71,6 +77,8 @@ class SignInButtonBuilder extends StatelessWidget {
     this.shape,
     this.height,
     this.width,
+    this.overflow = TextOverflow.ellipsis,
+    this.maxLines = 1,
   });
 
   /// The build funtion will be help user to build the signin button widget.
@@ -115,12 +123,16 @@ class SignInButtonBuilder extends StatelessWidget {
                   ),
               child: _getIconOrImage(),
             ),
-            Text(
-              text,
-              style: TextStyle(
-                color: textColor,
-                fontSize: fontSize,
-                backgroundColor: Color.fromRGBO(0, 0, 0, 0),
+            Flexible(
+              child: Text(
+                text,
+                maxLines: maxLines,
+                overflow: overflow,
+                style: TextStyle(
+                  color: textColor,
+                  fontSize: fontSize,
+                  backgroundColor: Color.fromRGBO(0, 0, 0, 0),
+                ),
               ),
             ),
           ],

--- a/lib/button_view.dart
+++ b/lib/button_view.dart
@@ -32,16 +32,24 @@ class SignInButton extends StatelessWidget {
   // overrides the default button elevation
   final double elevation;
 
+  /// overrides the default text overflow
+  final TextOverflow? overflow;
+
+  /// overrides the default max lines in case of text overflow
+  final int maxLines;
+
   /// The constructor is fairly self-explanatory.
   SignInButton(
     this.button, {
-    required this.onPressed,
-    this.mini = false,
-    this.padding = const EdgeInsets.all(0),
-    this.shape,
-    this.text,
-    this.elevation = 2.0,
-  }) : assert(
+      required this.onPressed,
+      this.mini = false,
+      this.padding = const EdgeInsets.all(0),
+      this.shape,
+      this.text,
+      this.elevation = 2.0,
+      this.overflow = TextOverflow.ellipsis,
+      this.maxLines = 1,
+      }) : assert(
             mini != true ||
                 !(button == Buttons.Google ||
                     button == Buttons.GoogleDark ||
@@ -84,6 +92,8 @@ class SignInButton extends StatelessWidget {
           innerPadding: EdgeInsets.all(0),
           shape: shape,
           height: 36.0,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Facebook:
       case Buttons.FacebookNew:
@@ -113,6 +123,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.GitHub:
         return SignInButtonBuilder(
@@ -125,6 +137,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Apple:
       case Buttons.AppleDark:
@@ -141,6 +155,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.LinkedIn:
         return SignInButtonBuilder(
@@ -153,6 +169,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Pinterest:
         return SignInButtonBuilder(
@@ -165,6 +183,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Tumblr:
         return SignInButtonBuilder(
@@ -177,6 +197,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Twitter:
         return SignInButtonBuilder(
@@ -189,6 +211,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Reddit:
         return SignInButtonBuilder(
@@ -201,6 +225,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Quora:
         return SignInButtonBuilder(
@@ -212,6 +238,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Yahoo:
         return SignInButtonBuilder(
@@ -223,6 +251,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Hotmail:
         return SignInButtonBuilder(
@@ -234,6 +264,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Xbox:
         return SignInButtonBuilder(
@@ -245,6 +277,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Microsoft:
         return SignInButtonBuilder(
@@ -256,6 +290,8 @@ class SignInButton extends StatelessWidget {
           onPressed: onPressed,
           padding: padding,
           shape: shape,
+          overflow: overflow,
+          maxLines: maxLines,
         );
       case Buttons.Email:
       default:


### PR DESCRIPTION
On a small, low-density screen, long text may overflow #88 
Add text overflow without changing the size of the button
(Default value is ellipsis)
![Capture](https://user-images.githubusercontent.com/25597296/146155336-7e3e96b8-8309-4296-b4cc-5d613312725d.JPG)
